### PR TITLE
use lowercase md5 dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var request = require('request');
 var qs = require('querystring');
-var md5 = require('MD5');
+var md5 = require('md5');
 var _ = require('underscore');
 
 function BaiduMap(config){

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "chai": "*"
   },
   "dependencies": {
-    "request": "~2.39.0",
-    "underscore": "~1.6.0",
+    "md5": "^2.0.0",
     "querystring": "~0.2.0",
-    "MD5": "~1.2.1"
+    "request": "~2.39.0",
+    "underscore": "~1.6.0"
   }
 }


### PR DESCRIPTION
npm has deprecated uppercase package names, making `npm install` fails.
